### PR TITLE
chore: improve post layout and image presentation

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -106,29 +106,6 @@ layout: default
     {%- endif -%}
   </nav>
 
-  {%- assign related = "" | split: "" -%}
-  {%- for post in site.posts -%}
-    {%- if post.url != page.url -%}
-      {%- for cat in post.categories -%}
-        {%- if page.categories contains cat -%}
-          {%- unless related contains post -%}
-            {%- assign related = related | push: post -%}
-          {%- endunless -%}
-        {%- endif -%}
-      {%- endfor -%}
-    {%- endif -%}
-  {%- endfor -%}
-  {%- assign related = related | limit: 3 -%}
-  {%- if related.size > 0 -%}
-  <section class="related-posts">
-    <h2 class="section-label">Related posts</h2>
-    <div class="post-grid post-grid--sm">
-      {%- for rpost in related -%}
-        {%- include post-card.html post=rpost -%}
-      {%- endfor -%}
-    </div>
-  </section>
-  {%- endif -%}
 </div>
 
 <script>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -373,16 +373,16 @@ a.cat-pill:hover {
    ============================================================ */
 
 .post-header-image-wrap {
-  width: 100%;
-  max-height: 500px;
-  overflow: hidden;
-  background: var(--bg-card);
+  max-width: 900px;
+  margin-inline: auto;
+  padding-inline: var(--gap);
+  padding-top: 2rem;
 }
 .post-header-image {
   width: 100%;
-  max-height: 500px;
-  object-fit: cover;
+  height: auto;
   display: block;
+  border-radius: 8px;
 }
 
 .post-container {
@@ -687,7 +687,16 @@ pre code,
   border-radius: var(--radius);
   margin: 1.5rem 0;
 }
-figure { margin: 1.75rem 0; }
+figure {
+  margin: 1.75rem 0;
+  width: 100%;
+}
+@media (min-width: 1200px) {
+  figure {
+    margin-inline: calc((var(--content) - var(--container)) / 2);
+    width: var(--container);
+  }
+}
 figure img { margin: 0 !important; width: 100%; border-radius: var(--radius); }
 figcaption {
   margin-top: .55rem;
@@ -696,6 +705,8 @@ figcaption {
   text-align: center;
   font-style: italic;
   line-height: 1.5;
+  max-width: var(--content);
+  margin-inline: auto;
 }
 
 /* Tables */
@@ -704,8 +715,6 @@ figcaption {
   border-collapse: collapse;
   margin: 1.75rem 0;
   font-size: .9rem;
-  display: block;
-  overflow-x: auto;
 }
 .post-content thead tr { border-bottom: 1px solid var(--accent); }
 .post-content th {
@@ -1184,7 +1193,7 @@ figcaption {
 #lightbox-overlay.open { display: flex; }
 
 #lightbox-img {
-  max-width: 100%;
+  width: 90vw;
   max-height: 90vh;
   object-fit: contain;
   border-radius: var(--radius);
@@ -1504,7 +1513,7 @@ figcaption {
 
   .about-grid { grid-template-columns: 1fr; }
 
-  .post-header-image-wrap { max-height: 280px; }
+  .post-header-image-wrap { width: 100%; }
 
   .cv-content { padding: 1.25rem; }
 }


### PR DESCRIPTION
## Summary

- Remove related posts section from post layout
- Post header image constrained to content width, displayed at natural aspect ratio (no cropping)
- In-post figures break out to full container width (1100px) on wide screens
- Lightbox images scale to 90vw instead of being capped at intrinsic SVG dimensions
- Figcaptions capped to content width (720px) and centered under wider figures
- Fix tables not stretching to 100% width (was caused by `display: block` on the table element)

🤖 Generated with [Claude Code](https://claude.com/claude-code)