### PR TITLE
chore: CV mobile layout and update site URL to mguarinos.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: Manuel Guarinos
 description: Writing on cloud engineering and SRE — things that took iterations to get right, and a few that just worked.
-url: "https://mguarinos.github.io"
+url: "https://mguarinos.com"
 baseurl: ""
 author: Manuel Guarinos
 

--- a/cv.html
+++ b/cv.html
@@ -387,6 +387,43 @@ permalink: /cv/
       page-break-before: always;
     }
 
+    /* ─── MOBILE ─── */
+    @media screen and (max-width: 600px) {
+      .cv-container {
+        padding: 20px 16px;
+        margin: 0 auto;
+      }
+
+      .header {
+        flex-direction: column-reverse;
+        align-items: center;
+        text-align: center;
+        gap: 14px;
+      }
+
+      .header-right {
+        margin-left: 0;
+      }
+
+      .contact-bar {
+        justify-content: center;
+        gap: 12px 18px;
+      }
+
+      .skills-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .entry-header {
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .entry-date {
+        white-space: normal;
+      }
+    }
+
     /* ─── PRINT ─── */
     @media print {
       body {

--- a/cv.html
+++ b/cv.html
@@ -511,8 +511,8 @@ permalink: /cv/
           href="mailto:manuelguarinos@gmail.com">manuelguarinos@gmail.com</a></div>
       <div class="contact-item"><i class="fab fa-linkedin"></i> <a href="http://linkedin.com/in/mguarinos"
           target="_blank">linkedin.com/in/mguarinos</a></div>
-      <div class="contact-item"><i class="fas fa-globe"></i> <a href="https://mguarinos.github.io"
-          target="_blank">mguarinos.github.io</a></div>
+      <div class="contact-item"><i class="fas fa-globe"></i> <a href="https://mguarinos.com"
+          target="_blank">mguarinos.com</a></div>
     </div>
 
     <!-- ABOUT ME -->


### PR DESCRIPTION
## Summary

- **CV mobile**: adds `@media screen and (max-width: 600px)` overrides — header stacks vertically (photo centered on top), skills grid goes single column, job entry headers stack title then date, container padding reduced from 38px to 16px horizontal, contact bar centers
- **Site URL**: `_config.yml` updated from `https://mguarinos.github.io` to `https://mguarinos.com` — affects canonical URLs, sitemap, RSS feed, and SEO tags
- **CV contact bar**: website link updated from `mguarinos.github.io` to `mguarinos.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)