### PR TITLE
chore: refactor header SVGs to 16:9 and fix mobile table scroll

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1515,6 +1515,12 @@ figcaption {
 
   .post-header-image-wrap { width: 100%; }
 
+  .post-content table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
   .cv-content { padding: 1.25rem; }
 }
 

--- a/assets/images/kubernetes-operator-pattern/header.svg
+++ b/assets/images/kubernetes-operator-pattern/header.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 400" width="1200" height="400">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 506" width="900" height="506">
   <defs>
     <linearGradient id="bg-b" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" style="stop-color:#0a0a0a"/>
@@ -16,273 +16,238 @@
             markerWidth="6" markerHeight="6" orient="auto-start-reverse">
       <path d="M0,1 L9,5 L0,9 Z" fill="#f6821f"/>
     </marker>
-    <clipPath id="left-clip">
-      <rect x="0" y="0" width="370" height="400"/>
-    </clipPath>
-    <clipPath id="right-clip">
-      <rect x="830" y="0" width="370" height="400"/>
-    </clipPath>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="400" fill="url(#bg-b)"/>
+  <rect width="900" height="506" fill="url(#bg-b)"/>
 
   <!-- Subtle grid -->
   <g stroke="#ffffff" stroke-opacity="0.02" stroke-width="1">
-    <line x1="0" y1="133" x2="1200" y2="133"/>
-    <line x1="0" y1="266" x2="1200" y2="266"/>
-    <line x1="200" y1="0" x2="200" y2="400"/>
-    <line x1="400" y1="0" x2="400" y2="400"/>
-    <line x1="600" y1="0" x2="600" y2="400"/>
-    <line x1="800" y1="0" x2="800" y2="400"/>
-    <line x1="1000" y1="0" x2="1000" y2="400"/>
+    <line x1="0" y1="169" x2="900" y2="169"/>
+    <line x1="0" y1="338" x2="900" y2="338"/>
+    <line x1="150" y1="0" x2="150" y2="506"/>
+    <line x1="300" y1="0" x2="300" y2="506"/>
+    <line x1="450" y1="0" x2="450" y2="506"/>
+    <line x1="600" y1="0" x2="600" y2="506"/>
+    <line x1="750" y1="0" x2="750" y2="506"/>
   </g>
 
-  <!-- ── LEFT PANEL: Kubernetes desired state (x=0–370) ─────────────────── -->
-
-  <!-- K8s blue left accent border -->
-  <rect x="0" y="0" width="3" height="400" fill="#326ce5"/>
+  <!-- ── LEFT PANEL: Kubernetes desired state (x=0–270) ──────────────────── -->
 
   <!-- "KUBERNETES" label -->
-  <text x="30" y="36"
+  <text x="20" y="66"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" font-weight="600" fill="#326ce5" letter-spacing="2">KUBERNETES</text>
 
   <!-- "kubectl apply" badge -->
-  <rect x="30" y="46" width="98" height="20" rx="3" fill="#1a2744"/>
-  <text x="79" y="60"
+  <rect x="20" y="76" width="90" height="20" rx="3" fill="#1a2744"/>
+  <text x="65" y="90"
         font-family="monospace" font-size="11" fill="#4da6ff" text-anchor="middle">kubectl apply</text>
 
   <!-- Code block background -->
-  <rect x="30" y="76" width="320" height="182" rx="6"
+  <rect x="20" y="106" width="238" height="222" rx="6"
         fill="#0f0f0f" stroke="#222222" stroke-width="1"/>
 
-  <!-- YAML content — line height 22px, starting y=98 -->
-  <!-- Line 1: kind: CloudflareDNSRecord -->
-  <text x="46" y="98" font-family="monospace" font-size="12">
+  <!-- YAML content — line-height 28px, starting y=132 -->
+  <text x="34" y="132" font-family="monospace" font-size="11">
     <tspan fill="#888888">kind: </tspan><tspan fill="#c9d1d9">CloudflareDNSRecord</tspan>
   </text>
-  <!-- Line 2: spec: -->
-  <text x="46" y="120" font-family="monospace" font-size="12">
+  <text x="34" y="160" font-family="monospace" font-size="11">
     <tspan fill="#888888">spec:</tspan>
   </text>
-  <!-- Line 3: name -->
-  <text x="46" y="142" font-family="monospace" font-size="12">
+  <text x="34" y="188" font-family="monospace" font-size="11">
     <tspan fill="#888888">  name: </tspan><tspan fill="#e0b04a">mguarinos.com</tspan>
   </text>
-  <!-- Line 4: type -->
-  <text x="46" y="164" font-family="monospace" font-size="12">
+  <text x="34" y="216" font-family="monospace" font-size="11">
     <tspan fill="#888888">  type: </tspan><tspan fill="#4da6ff">A</tspan>
   </text>
-  <!-- Line 5: content -->
-  <text x="46" y="186" font-family="monospace" font-size="12">
+  <text x="34" y="244" font-family="monospace" font-size="11">
     <tspan fill="#888888">  content: </tspan><tspan fill="#e0b04a">1.1.1.1</tspan>
   </text>
-  <!-- Line 6: ttl -->
-  <text x="46" y="208" font-family="monospace" font-size="12">
+  <text x="34" y="272" font-family="monospace" font-size="11">
     <tspan fill="#888888">  ttl: </tspan><tspan fill="#79c0ff">1</tspan>
   </text>
-  <!-- Line 7: proxied -->
-  <text x="46" y="230" font-family="monospace" font-size="12">
+  <text x="34" y="300" font-family="monospace" font-size="11">
     <tspan fill="#888888">  proxied: </tspan><tspan fill="#d2a8ff">false</tspan>
   </text>
 
   <!-- "desired state" label below code block -->
-  <text x="190" y="282"
+  <text x="139" y="356"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" fill="#333333" text-anchor="middle" letter-spacing="1">desired state</text>
 
-  <!-- ── LEFT → CENTER ARROW (x=370–430) ──────────────────────────────────── -->
-  <line x1="358" y1="185" x2="428" y2="185"
+  <!-- ── LEFT → CENTER ARROW ───────────────────────────────────────────── -->
+  <line x1="260" y1="216" x2="328" y2="216"
         stroke="#4da6ff" stroke-width="1.5" stroke-dasharray="4,3"
         marker-end="url(#b-arr-blue)"/>
-  <text x="393" y="177"
+  <text x="294" y="208"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="10" fill="#4da6ff" text-anchor="middle">spec</text>
 
-  <!-- ── CENTER PANEL: Operator reconciliation loop (x=430–770) ─────────── -->
+  <!-- ── CENTER PANEL: Operator reconciliation loop (x=330–580) ────────── -->
 
   <!-- Operator label -->
-  <text x="600" y="36"
+  <text x="455" y="66"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="11" fill="#555555" text-anchor="middle" letter-spacing="0.3">
+        font-size="10" fill="#555555" text-anchor="middle" letter-spacing="0.3">
     kubernetes-cloudflare-dns-operator
   </text>
 
-  <!-- Title -->
-  <text x="600" y="62"
+  <!-- Title (two lines) -->
+  <text x="455" y="90"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="13" fill="#444444" text-anchor="middle" letter-spacing="0.3">
-    Understanding the
+        font-size="12" fill="#444444" text-anchor="middle">Understanding the</text>
+  <text x="455" y="116"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-size="18" font-weight="700" fill="#cccccc" text-anchor="middle" letter-spacing="-0.3">
+    Operator
   </text>
-  <text x="600" y="90"
+  <text x="455" y="140"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="22" font-weight="700" fill="#cccccc" text-anchor="middle" letter-spacing="-0.3">
-    Operator Reconciliation Loop
+        font-size="18" font-weight="700" fill="#cccccc" text-anchor="middle" letter-spacing="-0.3">
+    Reconciliation Loop
   </text>
 
-  <!-- 2×2 box layout:
-       Box width=110, height=44, h-gap=26, v-gap=24
-       Total: 2*110+26=246 wide, 2*44+24=112 high
-       x center=600 → x start=600-123=477
-       Watch(TL): x=477, Compare(TR): x=613
-       PatchStatus(BL): x=477, Reconcile(BR): x=613
-       y top=154, y bottom=154+44+24=222 -->
+  <!-- 2×2 boxes: width=100, height=50, h-gap=18, v-gap=22
+       Total width: 218, center at 455 → left x=346, right x=464
+       Top row y=164, bottom row y=236 -->
 
-  <!-- Box: Watch (top-left) -->
-  <rect x="477" y="154" width="110" height="44" rx="5"
+  <!-- Box: Watch (TL) -->
+  <rect x="346" y="164" width="100" height="50" rx="5"
         fill="#1a1a1a" stroke="#333333" stroke-width="1.5"/>
-  <text x="532" y="173"
+  <text x="396" y="184"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" font-weight="600" fill="#cccccc" text-anchor="middle">Watch</text>
-  <text x="532" y="188"
+  <text x="396" y="200"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="9" fill="#555555" text-anchor="middle">K8s events + timer</text>
 
-  <!-- Box: Compare (top-right) -->
-  <rect x="613" y="154" width="110" height="44" rx="5"
+  <!-- Box: Compare (TR) -->
+  <rect x="464" y="164" width="100" height="50" rx="5"
         fill="#1a1a1a" stroke="#333333" stroke-width="1.5"/>
-  <text x="668" y="173"
+  <text x="514" y="184"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" font-weight="600" fill="#cccccc" text-anchor="middle">Compare</text>
-  <text x="668" y="188"
+  <text x="514" y="200"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="9" fill="#555555" text-anchor="middle">spec vs live</text>
 
-  <!-- Box: Reconcile (bottom-right, blue = action) -->
-  <rect x="613" y="222" width="110" height="44" rx="5"
+  <!-- Box: Reconcile (BR) — blue border = action -->
+  <rect x="464" y="236" width="100" height="50" rx="5"
         fill="#1a1a1a" stroke="#4da6ff" stroke-width="1.5"/>
-  <text x="668" y="241"
+  <text x="514" y="256"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" font-weight="600" fill="#cccccc" text-anchor="middle">Reconcile</text>
-  <text x="668" y="256"
+  <text x="514" y="272"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="9" fill="#4da6ff" text-anchor="middle">Cloudflare API</text>
 
-  <!-- Box: Patch Status (bottom-left) -->
-  <rect x="477" y="222" width="110" height="44" rx="5"
+  <!-- Box: Patch Status (BL) -->
+  <rect x="346" y="236" width="100" height="50" rx="5"
         fill="#1a1a1a" stroke="#333333" stroke-width="1.5"/>
-  <text x="532" y="241"
+  <text x="396" y="256"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" font-weight="600" fill="#cccccc" text-anchor="middle">Patch Status</text>
-  <text x="532" y="256"
+  <text x="396" y="272"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="9" fill="#555555" text-anchor="middle">Synced: True</text>
 
   <!-- Clockwise arrows between boxes -->
-  <!-- Watch → Compare (right) -->
-  <line x1="588" y1="176" x2="612" y2="176"
+  <!-- Watch → Compare -->
+  <line x1="447" y1="189" x2="463" y2="189"
         stroke="#555555" stroke-width="1.2" marker-end="url(#b-arr)"/>
-  <!-- Compare → Reconcile (down) -->
-  <line x1="668" y1="199" x2="668" y2="221"
+  <!-- Compare → Reconcile -->
+  <line x1="514" y1="215" x2="514" y2="235"
         stroke="#555555" stroke-width="1.2" marker-end="url(#b-arr)"/>
-  <!-- Reconcile → Patch Status (left) -->
-  <line x1="612" y1="244" x2="588" y2="244"
+  <!-- Reconcile → Patch Status -->
+  <line x1="463" y1="261" x2="447" y2="261"
         stroke="#555555" stroke-width="1.2" marker-end="url(#b-arr)"/>
-  <!-- Patch Status → Watch (up) -->
-  <line x1="532" y1="221" x2="532" y2="199"
+  <!-- Patch Status → Watch -->
+  <line x1="396" y1="235" x2="396" y2="215"
         stroke="#555555" stroke-width="1.2" marker-end="url(#b-arr)"/>
 
-  <!-- Synced status badge below loop -->
-  <rect x="560" y="290" width="80" height="20" rx="10"
+  <!-- Synced status badge -->
+  <rect x="415" y="305" width="80" height="22" rx="11"
         fill="#0d2e16" stroke="#2ea043" stroke-width="1"/>
-  <text x="600" y="304"
+  <text x="455" y="320"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="10" fill="#3fb950" text-anchor="middle">● Synced: True</text>
 
-  <!-- ── CENTER → RIGHT ARROW (x=770–830) ─────────────────────────────────── -->
-  <line x1="772" y1="185" x2="828" y2="185"
+  <!-- ── CENTER → RIGHT ARROW ──────────────────────────────────────────── -->
+  <line x1="582" y1="216" x2="633" y2="216"
         stroke="#f6821f" stroke-width="1.5" stroke-dasharray="4,3"
         marker-end="url(#b-arr-orange)"/>
-  <text x="800" y="177"
+  <text x="607" y="208"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="10" fill="#f6821f" text-anchor="middle">sync</text>
 
-  <!-- ── RIGHT PANEL: Cloudflare live state (x=830–1200) ───────────────────── -->
-
-  <!-- Cloudflare orange top accent border -->
-  <rect x="830" y="0" width="370" height="3" fill="#f6821f"/>
-  <!-- Right accent border -->
-  <rect x="1197" y="0" width="3" height="400" fill="#f6821f" opacity="0.4"/>
+  <!-- ── RIGHT PANEL: Cloudflare live state (x=635–900) ───────────────── -->
 
   <!-- "CLOUDFLARE" label -->
-  <text x="860" y="36"
+  <text x="653" y="66"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" font-weight="600" fill="#f6821f" letter-spacing="2">CLOUDFLARE</text>
 
   <!-- "DNS Records" heading -->
-  <text x="860" y="62"
+  <text x="653" y="90"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="18" font-weight="700" fill="#ffffff">DNS Records</text>
-  <text x="860" y="80"
+        font-size="17" font-weight="700" fill="#ffffff">DNS Records</text>
+  <text x="653" y="108"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" fill="#555555">mguarinos.com</text>
 
   <!-- Table panel background -->
-  <rect x="848" y="92" width="334" height="180" rx="6"
+  <rect x="639" y="118" width="252" height="192" rx="6"
         fill="#0f0f0f" stroke="#1e2028" stroke-width="1"/>
 
   <!-- Table header row -->
-  <rect x="848" y="92" width="334" height="28" rx="6" fill="#141414"/>
-  <rect x="848" y="106" width="334" height="14" fill="#141414"/><!-- square bottom corners -->
-  <text x="868" y="111" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+  <rect x="639" y="118" width="252" height="28" rx="6" fill="#141414"/>
+  <rect x="639" y="132" width="252" height="14" fill="#141414"/>
+  <text x="652" y="136" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="10" fill="#555555" font-weight="600">Type</text>
-  <text x="918" y="111" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+  <text x="694" y="136" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="10" fill="#555555" font-weight="600">Name</text>
-  <text x="1030" y="111" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+  <text x="772" y="136" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="10" fill="#555555" font-weight="600">Content</text>
-  <text x="1130" y="111" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+  <text x="848" y="136" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="10" fill="#555555" font-weight="600">TTL</text>
 
-  <!-- Row separator -->
-  <line x1="848" y1="120" x2="1182" y2="120" stroke="#1e2028" stroke-width="1"/>
+  <line x1="639" y1="146" x2="891" y2="146" stroke="#1e2028" stroke-width="1"/>
 
   <!-- Row 1: A record -->
-  <!-- Type badge -->
-  <rect x="858" y="128" width="24" height="16" rx="3" fill="#1a3050"/>
-  <text x="870" y="140" font-family="monospace" font-size="10" fill="#4da6ff" text-anchor="middle">A</text>
-  <!-- Name -->
-  <text x="918" y="140" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="11" fill="#cccccc">mguarinos.com</text>
-  <!-- Content -->
-  <text x="1030" y="140" font-family="monospace" font-size="11" fill="#e0b04a">1.1.1.1</text>
-  <!-- TTL -->
-  <text x="1130" y="140" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="11" fill="#666666">Auto</text>
+  <rect x="643" y="153" width="22" height="16" rx="3" fill="#1a3050"/>
+  <text x="654" y="165" font-family="monospace" font-size="10" fill="#4da6ff" text-anchor="middle">A</text>
+  <text x="694" y="165" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-size="10" fill="#cccccc">mguarinos.com</text>
+  <text x="772" y="165" font-family="monospace" font-size="10" fill="#e0b04a">1.1.1.1</text>
+  <text x="848" y="165" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-size="10" fill="#666666">Auto</text>
 
-  <!-- Row separator -->
-  <line x1="848" y1="152" x2="1182" y2="152" stroke="#1a1a1a" stroke-width="1"/>
+  <line x1="639" y1="179" x2="891" y2="179" stroke="#1a1a1a" stroke-width="1"/>
 
   <!-- Row 2: TXT record -->
-  <!-- Type badge -->
-  <rect x="854" y="160" width="32" height="16" rx="3" fill="#1e1a30"/>
-  <text x="870" y="172" font-family="monospace" font-size="10" fill="#9b8dca" text-anchor="middle">TXT</text>
-  <!-- Name -->
-  <text x="918" y="172" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="11" fill="#cccccc">mguarinos.com</text>
-  <!-- Content -->
-  <text x="1030" y="172" font-family="monospace" font-size="11" fill="#888888">Hello world!</text>
-  <!-- TTL -->
-  <text x="1130" y="172" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="11" fill="#666666">5 min</text>
+  <rect x="640" y="186" width="28" height="16" rx="3" fill="#1e1a30"/>
+  <text x="654" y="198" font-family="monospace" font-size="10" fill="#9b8dca" text-anchor="middle">TXT</text>
+  <text x="694" y="198" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-size="10" fill="#cccccc">mguarinos.com</text>
+  <text x="772" y="198" font-family="monospace" font-size="10" fill="#888888">Hello world!</text>
+  <text x="848" y="198" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-size="10" fill="#666666">5 min</text>
 
-  <!-- Row separator -->
-  <line x1="848" y1="184" x2="1182" y2="184" stroke="#1a1a1a" stroke-width="1"/>
+  <line x1="639" y1="212" x2="891" y2="212" stroke="#1a1a1a" stroke-width="1"/>
 
-  <!-- Faded row 3 (suggests more records) -->
-  <rect x="854" y="192" width="24" height="16" rx="3" fill="#141414"/>
-  <text x="918" y="204" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="11" fill="#2a2a2a">···</text>
+  <!-- Faded row 3 -->
+  <rect x="640" y="219" width="22" height="16" rx="3" fill="#141414"/>
+  <text x="694" y="231" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-size="10" fill="#2a2a2a">···</text>
 
   <!-- "live state" label -->
-  <text x="1015" y="296"
+  <text x="765" y="348"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-size="11" fill="#333333" text-anchor="middle" letter-spacing="1">live state</text>
 
-  <!-- Drift warning note (small, bottom right) -->
-  <text x="860" y="356"
+  <!-- Drift warning note -->
+  <text x="648" y="422"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-size="10" fill="#333333">
-    External edits reverted within 60 s
-  </text>
+        font-size="10" fill="#333333">External edits reverted within 60 s</text>
 </svg>

--- a/assets/images/streamline/header.svg
+++ b/assets/images/streamline/header.svg
@@ -1,69 +1,67 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 400" width="1200" height="400">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 506" width="900" height="506">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0a0a"/>
       <stop offset="100%" style="stop-color:#1a1a2e"/>
     </linearGradient>
-    <linearGradient id="wave" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#e63946;stop-opacity:0"/>
-      <stop offset="40%" style="stop-color:#e63946;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#e63946;stop-opacity:0.3"/>
-    </linearGradient>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="400" fill="url(#bg)"/>
+  <rect width="900" height="506" fill="url(#bg)"/>
 
   <!-- Subtle grid -->
   <g stroke="#ffffff" stroke-opacity="0.03" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="200" y1="0" x2="200" y2="400"/>
-    <line x1="400" y1="0" x2="400" y2="400"/>
-    <line x1="600" y1="0" x2="600" y2="400"/>
-    <line x1="800" y1="0" x2="800" y2="400"/>
-    <line x1="1000" y1="0" x2="1000" y2="400"/>
+    <line x1="0" y1="126" x2="900" y2="126"/>
+    <line x1="0" y1="253" x2="900" y2="253"/>
+    <line x1="0" y1="380" x2="900" y2="380"/>
+    <line x1="150" y1="0" x2="150" y2="506"/>
+    <line x1="300" y1="0" x2="300" y2="506"/>
+    <line x1="450" y1="0" x2="450" y2="506"/>
+    <line x1="600" y1="0" x2="600" y2="506"/>
+    <line x1="750" y1="0" x2="750" y2="506"/>
   </g>
 
   <!-- HLS waveform bars (decorative) -->
   <g fill="#e63946" opacity="0.15">
-    <rect x="80"  y="170" width="8" height="60"/>
-    <rect x="96"  y="155" width="8" height="90"/>
-    <rect x="112" y="145" width="8" height="110"/>
-    <rect x="128" y="160" width="8" height="80"/>
-    <rect x="144" y="140" width="8" height="120"/>
-    <rect x="160" y="150" width="8" height="100"/>
-    <rect x="176" y="165" width="8" height="70"/>
+    <rect x="60"  y="215" width="8" height="60"/>
+    <rect x="74"  y="200" width="8" height="90"/>
+    <rect x="88"  y="190" width="8" height="110"/>
+    <rect x="102" y="205" width="8" height="80"/>
+    <rect x="116" y="185" width="8" height="120"/>
+    <rect x="130" y="195" width="8" height="100"/>
+    <rect x="144" y="210" width="8" height="70"/>
   </g>
   <g fill="#e63946" opacity="0.4">
-    <rect x="80"  y="185" width="8" height="30"/>
-    <rect x="96"  y="178" width="8" height="44"/>
-    <rect x="112" y="172" width="8" height="56"/>
-    <rect x="128" y="182" width="8" height="36"/>
-    <rect x="144" y="170" width="8" height="60"/>
-    <rect x="160" y="176" width="8" height="48"/>
-    <rect x="176" y="187" width="8" height="26"/>
+    <rect x="60"  y="230" width="8" height="30"/>
+    <rect x="74"  y="223" width="8" height="44"/>
+    <rect x="88"  y="217" width="8" height="56"/>
+    <rect x="102" y="227" width="8" height="36"/>
+    <rect x="116" y="215" width="8" height="60"/>
+    <rect x="130" y="221" width="8" height="48"/>
+    <rect x="144" y="232" width="8" height="26"/>
   </g>
 
   <!-- LIVE badge -->
-  <rect x="80" y="96" width="56" height="22" rx="3" fill="#e63946"/>
-  <text x="108" y="111" font-family="monospace" font-size="11" font-weight="bold" fill="#ffffff" text-anchor="middle">LIVE</text>
+  <rect x="60" y="130" width="56" height="22" rx="3" fill="#e63946"/>
+  <text x="88" y="145" font-family="monospace" font-size="11" font-weight="bold" fill="#ffffff" text-anchor="middle">LIVE</text>
 
   <!-- Main title -->
-  <text x="600" y="190" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+  <text x="450" y="250"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
         font-size="64" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="-2">
     Streamline
   </text>
 
   <!-- Subtitle -->
-  <text x="600" y="240" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+  <text x="450" y="302"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
         font-size="20" fill="#888888" text-anchor="middle" letter-spacing="1">
     Serverless live streaming · 4-hour DVR · AWS IVS + CloudFront
   </text>
 
   <!-- Bottom tag line -->
-  <text x="600" y="330" font-family="monospace" font-size="13" fill="#444444" text-anchor="middle">
+  <text x="450" y="420"
+        font-family="monospace" font-size="13" fill="#444444" text-anchor="middle">
     IVS  ·  CloudFront  ·  Lambda  ·  EventBridge  ·  SSM  ·  Terraform
   </text>
 </svg>


### PR DESCRIPTION
## Summary

- Resize Streamline and Kubernetes Operator Pattern post headers from 3:1 ratio to 900×506 (16:9) — matches the OIDC post header and prevents cropping in the post listing grid
- Improve vertical centering on the Kubernetes header and remove edge accent borders that looked like image artifacts
- Add `overflow-x: auto` to post tables on mobile (≤768px) so wide tables scroll horizontally instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)