### PR TITLE
fix: add explicit og:image meta tag for LinkedIn

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,4 +20,8 @@
   </script>
   {%- feed_meta -%}
   {%- seo -%}
+  {%- assign _og_image = page.image | default: site.image.path -%}
+  {%- if _og_image -%}
+  <meta name="image" property="og:image" content="{{ _og_image | absolute_url }}">
+  {%- endif -%}
 </head>


### PR DESCRIPTION
## Summary

LinkedIn's Post Inspector requires `<meta name="image" property="og:image" ...>` — with both attributes on the same tag. `jekyll-seo-tag` only emits `property="og:image"` alone, which is standard Open Graph but not what LinkedIn specifically looks for.

This adds an explicit tag after `{% seo %}` for both the site default image (homepage) and per-post images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)