### PR TITLE
feat: series infrastructure

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,9 @@ social:
 collections:
   projects:
     output: false
+  series:
+    output: true
+    permalink: /posts/:path/
 
 plugins:
   - jekyll-feed
@@ -35,6 +38,8 @@ kramdown:
   input: GFM
   syntax_highlighter: rouge
 
+future: true
+
 permalink: /posts/:year/:month/:day/:title/
 
 defaults:
@@ -43,6 +48,15 @@ defaults:
       type: posts
     values:
       layout: post
+  - scope:
+      path: "_series/ollama-infra-series"
+      type: series
+    values:
+      layout: post
+      date: "2026-04-27"
+      series: "Self-hosted AI Inference with Ollama"
+      categories: [ollama, infra, ai]
+      image: /assets/images/ollama-infra-series/header.svg
 
 exclude:
   - Gemfile

--- a/_data/series.yml
+++ b/_data/series.yml
@@ -1,0 +1,5 @@
+- name: "Self-hosted AI Inference with Ollama"
+  slug: "ollama-infra-series"
+  date: "April 2026"
+  description: "Go from a bare server to a production-grade local AI inference stack. Each post adds one layer — runtime, reverse proxy, async queue, chat UI, voice interface, code assistant integration, and observability. By the end you have a complete, self-hosted setup you understand top to bottom."
+  image: /assets/images/ollama-infra-series/header.svg

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,6 +4,7 @@
     <nav class="site-nav" role="navigation" aria-label="Main navigation">
       <ul class="nav-links">
         <li><a href="{{ '/' | relative_url }}"{% if page.url == '/' %} class="active"{% endif %}>Writing</a></li>
+        <li><a href="{{ '/series/' | relative_url }}"{% if page.url contains '/series' %} class="active"{% endif %}>Series</a></li>
         <li><a href="{{ '/portfolio/' | relative_url }}"{% if page.url contains '/portfolio' %} class="active"{% endif %}>Portfolio</a></li>
         <li><a href="{{ '/categories/' | relative_url }}"{% if page.url contains '/categories' %} class="active"{% endif %}>Categories</a></li>
         <li><a href="{{ '/cv/' | relative_url }}"{% if page.url contains '/cv' %} class="active"{% endif %}>CV</a></li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,6 +3,46 @@ layout: default
 ---
 <div id="progress-bar" role="progressbar" aria-label="Reading progress"></div>
 
+{%- if page.title -%}
+{%- assign rb_series = site.series | where: "series", page.series | sort: "series_part" -%}
+{%- if rb_series.size == 0 and page.series -%}
+  {%- assign rb_series = site.posts | where: "series", page.series | sort: "series_part" -%}
+{%- endif -%}
+<div class="post-reading-bar" id="post-reading-bar">
+  <div class="container post-reading-bar-inner">
+    <span class="post-reading-title">{{ page.title | escape }}</span>
+    {%- if page.series and rb_series.size > 1 -%}
+    <div class="post-reading-series">
+      <button class="post-reading-series-btn" id="reading-series-btn" aria-expanded="false">
+        <span>Part {{ page.series_part }}</span>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="post-reading-series-panel" id="reading-series-panel" hidden>
+        <p class="reading-series-name">{{ page.series | escape }}</p>
+        <ol class="reading-series-list">
+          {%- for sp in rb_series -%}
+          <li>
+            {%- if sp.url == page.url -%}
+            <span class="reading-series-current">
+              <span class="reading-series-num">{{ sp.series_part }}.</span>
+              {{ sp.title | escape }}
+            </span>
+            {%- else -%}
+            <a href="{{ sp.url | relative_url }}" class="reading-series-link">
+              <span class="reading-series-num">{{ sp.series_part }}.</span>
+              {{ sp.title | escape }}
+            </a>
+            {%- endif -%}
+          </li>
+          {%- endfor -%}
+        </ol>
+      </div>
+    </div>
+    {%- endif -%}
+  </div>
+</div>
+{%- endif -%}
+
 {%- if page.image -%}
 <div class="post-header-image-wrap">
   <img src="{{ page.image | relative_url }}" alt="{{ page.title | escape }}" class="post-header-image">
@@ -38,33 +78,6 @@ layout: default
     </a>
     {%- endif -%}
 
-    {%- if page.series -%}
-      {%- assign series_posts = site.posts | where: "series", page.series | sort: "date" -%}
-      {%- if series_posts.size > 1 -%}
-      <div class="post-series">
-        <p class="post-series-label">Series</p>
-        <p class="post-series-title">{{ page.series }}</p>
-        <ol class="post-series-list">
-          {%- for sp in series_posts -%}
-            <li>
-              {%- if sp.url == page.url -%}
-                <span class="series-current">
-                  <span class="series-num">{{ forloop.index }}.</span>
-                  {{ sp.title | escape }}
-                </span>
-              {%- else -%}
-                <a href="{{ sp.url | relative_url }}">
-                  <span class="series-num">{{ forloop.index }}.</span>
-                  {{ sp.title | escape }}
-                </a>
-              {%- endif -%}
-            </li>
-          {%- endfor -%}
-        </ol>
-      </div>
-      {%- endif -%}
-    {%- endif -%}
-
     {%- if page.toc -%}
     <details class="toc-container" open>
       <summary class="toc-title">Contents</summary>
@@ -89,19 +102,40 @@ layout: default
 
   </article>
 
+  {%- assign nav_prev = nil -%}
+  {%- assign nav_next = nil -%}
+  {%- if page.collection == "series" and page.series -%}
+    {%- assign s_all = site.series | where: "series", page.series | sort: "series_part" -%}
+    {%- for sp in s_all -%}
+      {%- if sp.url == page.url -%}
+        {%- unless forloop.first -%}
+          {%- assign prev_idx = forloop.index0 | minus: 1 -%}
+          {%- assign nav_prev = s_all[prev_idx] -%}
+        {%- endunless -%}
+        {%- unless forloop.last -%}
+          {%- assign next_idx = forloop.index0 | plus: 1 -%}
+          {%- assign nav_next = s_all[next_idx] -%}
+        {%- endunless -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- else -%}
+    {%- assign nav_prev = page.previous -%}
+    {%- assign nav_next = page.next -%}
+  {%- endif -%}
+
   <nav class="post-nav" aria-label="Post navigation">
-    {%- if page.previous -%}
-      <a href="{{ page.previous.url | relative_url }}" class="post-nav-item post-nav-prev">
+    {%- if nav_prev -%}
+      <a href="{{ nav_prev.url | relative_url }}" class="post-nav-item post-nav-prev">
         <span class="post-nav-label">← Previous</span>
-        <span class="post-nav-title">{{ page.previous.title | escape }}</span>
+        <span class="post-nav-title">{{ nav_prev.title | escape }}</span>
       </a>
     {%- else -%}
       <span class="post-nav-item post-nav-placeholder"></span>
     {%- endif -%}
-    {%- if page.next -%}
-      <a href="{{ page.next.url | relative_url }}" class="post-nav-item post-nav-next">
+    {%- if nav_next -%}
+      <a href="{{ nav_next.url | relative_url }}" class="post-nav-item post-nav-next">
         <span class="post-nav-label">Next →</span>
-        <span class="post-nav-title">{{ page.next.title | escape }}</span>
+        <span class="post-nav-title">{{ nav_next.title | escape }}</span>
       </a>
     {%- endif -%}
   </nav>
@@ -109,6 +143,40 @@ layout: default
 </div>
 
 <script>
+  document.body.classList.add('is-post');
+
+  // Reading bar: appears when post title scrolls out of view (all viewports)
+  (function () {
+    var readingBar = document.getElementById('post-reading-bar');
+    var postTitle  = document.querySelector('.post-title');
+    if (!readingBar || !postTitle) return;
+    var io = new IntersectionObserver(function (entries) {
+      readingBar.classList.toggle('visible', !entries[0].isIntersecting);
+    }, { threshold: 0 });
+    io.observe(postTitle);
+  })();
+
+  // Series dropdown in reading bar
+  (function () {
+    var btn   = document.getElementById('reading-series-btn');
+    var panel = document.getElementById('reading-series-panel');
+    var btt   = document.getElementById('back-to-top');
+    if (!btn || !panel) return;
+    btn.addEventListener('click', function () {
+      var open = panel.hidden;
+      panel.hidden = !open;
+      btn.setAttribute('aria-expanded', String(open));
+      if (btt) btt.style.visibility = open ? 'hidden' : '';
+    });
+    document.addEventListener('click', function (e) {
+      if (!btn.contains(e.target) && !panel.contains(e.target)) {
+        panel.hidden = true;
+        btn.setAttribute('aria-expanded', 'false');
+        if (btt) btt.style.visibility = '';
+      }
+    });
+  })();
+
   (function () {
     var bar = document.getElementById('progress-bar');
     if (!bar) return;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1413,30 +1413,52 @@ figcaption {
   border: 1px solid var(--border);
   border-left: 3px solid #8b5cf6;
   border-radius: 0 var(--radius) var(--radius) 0;
-  padding: 1rem 1.25rem;
   margin: 2rem 0;
+}
+.post-series-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+  padding: .9rem 1.25rem;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  &::-webkit-details-marker { display: none; }
+  &::marker { display: none; }
+}
+.post-series-summary-inner {
+  display: flex;
+  flex-direction: column;
+  gap: .15rem;
 }
 .post-series-label {
   font-size: .7rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: .1em;
+  letter-spacing: .08em;
   color: #8b5cf6;
-  margin-bottom: .5rem;
 }
 .post-series-title {
-  font-size: .95rem;
+  font-size: .9rem;
   font-weight: 600;
   color: var(--text);
-  margin-bottom: .65rem;
+  line-height: 1.35;
 }
+.post-series-chevron {
+  flex-shrink: 0;
+  color: var(--text-3);
+  transition: transform .2s;
+}
+.post-series[open] .post-series-chevron { transform: rotate(180deg); }
 .post-series-list {
   list-style: none;
-  padding: 0;
+  padding: .25rem 1.25rem .9rem;
   margin: 0;
   display: flex;
   flex-direction: column;
   gap: .3rem;
+  border-top: 1px solid var(--border);
 }
 .post-series-list li { margin: 0; }
 .post-series-list a {
@@ -1463,6 +1485,435 @@ figcaption {
 }
 
 /* ============================================================
+   POST READING BAR
+   ============================================================ */
+
+.post-reading-bar {
+  position: sticky;
+  top: var(--header-h);
+  z-index: 90;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s;
+  &.visible { opacity: 1; pointer-events: auto; }
+}
+
+.post-reading-bar-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  height: 40px;
+}
+
+.post-reading-title {
+  font-size: .82rem;
+  font-weight: 500;
+  color: var(--text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.post-reading-series { position: relative; flex-shrink: 0; }
+
+.post-reading-series-btn {
+  display: flex;
+  align-items: center;
+  gap: .3rem;
+  font-size: .75rem;
+  font-weight: 500;
+  color: #8b5cf6;
+  background: rgba(139, 92, 246, .08);
+  border: 1px solid rgba(139, 92, 246, .25);
+  border-radius: var(--radius);
+  padding: .28rem .6rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background .15s;
+  &:hover { background: rgba(139, 92, 246, .16); }
+  svg { transition: transform .2s; }
+  &[aria-expanded="true"] svg { transform: rotate(180deg); }
+}
+
+.post-reading-series-panel {
+  position: absolute;
+  top: calc(100% + .4rem);
+  right: 0;
+  min-width: 280px;
+  max-width: 360px;
+  max-height: min(360px, 70vh);
+  overflow-y: auto;
+  background: var(--bg-card);
+  border: 1px solid var(--border-em);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  z-index: 100;
+}
+
+.reading-series-name {
+  font-size: .68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: #8b5cf6;
+  padding: .7rem 1rem .35rem;
+  margin: 0;
+}
+
+.reading-series-list {
+  list-style: none;
+  padding: .2rem 0 .5rem;
+  margin: 0;
+  li { margin: 0; }
+}
+
+.reading-series-link,
+.reading-series-current {
+  display: flex;
+  align-items: baseline;
+  gap: .5rem;
+  padding: .42rem 1rem;
+  font-size: .82rem;
+  text-decoration: none;
+}
+
+.reading-series-link {
+  color: var(--text-3);
+  &:hover { background: var(--bg-card-2); color: var(--text); }
+}
+
+.reading-series-current {
+  color: var(--text);
+  font-weight: 500;
+  background: var(--accent-sub);
+}
+
+.reading-series-num {
+  font-size: .7rem;
+  color: var(--text-3);
+  min-width: 1.2rem;
+  flex-shrink: 0;
+}
+
+@media (max-width: 767px) {
+  .post-reading-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: var(--header-h);
+    background: rgba(13, 17, 23, .92);
+    backdrop-filter: blur(12px);
+    border-bottom: none;
+    z-index: 101;
+  }
+  [data-theme="light"] .post-reading-bar { background: rgba(246, 248, 250, .92); }
+  .post-reading-bar-inner { height: var(--header-h); padding: 0 1rem; }
+  .post-reading-series-panel { max-width: calc(100vw - 2rem); }
+}
+
+/* ============================================================
+   SERIES PAGE
+   ============================================================ */
+
+.series-page { padding-top: 2.5rem; padding-bottom: 3rem; }
+
+.series-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.series-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color .2s, box-shadow .2s;
+}
+.series-card:hover {
+  border-color: var(--border-em);
+  box-shadow: var(--shadow-md);
+}
+
+.series-card-header {
+  padding: 1.25rem 1.5rem;
+  background: var(--bg-card-2);
+  border-bottom: 1px solid var(--border);
+  border-left: 3px solid #8b5cf6;
+}
+
+.series-card-image {
+  img {
+    width: 100%;
+    height: 160px;
+    object-fit: cover;
+    display: block;
+    filter: brightness(.8);
+  }
+}
+
+.series-repo-btn,
+.series-share-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  font-size: .72rem;
+  font-weight: 500;
+  font-family: inherit;
+  border-radius: var(--radius);
+  padding: .28rem .6rem;
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.series-repo-btn {
+  color: var(--text-3);
+  background: none;
+  border: 1px solid var(--border-em);
+  transition: color .15s, border-color .15s;
+  &:hover { color: var(--text); border-color: var(--text-3); }
+}
+
+.series-share-btn {
+  color: var(--text-3);
+  background: none;
+  border: 1px solid var(--border-em);
+  transition: color .15s, border-color .15s;
+  &:hover, &--copied { color: var(--text); border-color: var(--text-3); }
+}
+
+.series-card-label {
+  display: inline-block;
+  font-size: .65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: #8b5cf6;
+  margin-bottom: .4rem;
+}
+
+.series-card-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 .5rem;
+  line-height: 1.3;
+}
+
+.series-card-info {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: .5rem;
+}
+
+.series-card-info-actions {
+  display: flex;
+  align-items: center;
+  gap: .3rem;
+  margin-left: auto;
+}
+
+.series-card-count {
+  font-size: .72rem;
+  font-weight: 500;
+  color: #8b5cf6;
+  background: rgba(139, 92, 246, .12);
+  border: 1px solid rgba(139, 92, 246, .25);
+  border-radius: 100px;
+  padding: .2rem .65rem;
+  line-height: 1;
+}
+
+.series-card-dates {
+  font-size: .75rem;
+  color: var(--text-3);
+}
+
+.series-card-desc {
+  font-size: .82rem;
+  color: var(--text-3);
+  line-height: 1.55;
+  margin: .35rem 0 .6rem;
+}
+
+.series-card-total-time {
+  font-size: .72rem;
+  font-weight: 500;
+  color: var(--text-3);
+  background: var(--bg-card-2);
+  border: 1px solid var(--border-em);
+  border-radius: 100px;
+  padding: .2rem .65rem;
+  line-height: 1;
+}
+
+.series-card-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .6rem 1.5rem;
+  border-top: 1px solid var(--border);
+  gap: 1rem;
+}
+
+.series-start-btn {
+  display: inline-flex;
+  align-items: center;
+  font-size: .82rem;
+  font-weight: 600;
+  font-family: inherit;
+  padding: .5rem 1.1rem;
+  border-radius: var(--radius);
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+  margin: 0;
+  color: #a78bfa;
+  background: rgba(139, 92, 246, .12);
+  border: 1px solid rgba(139, 92, 246, .35);
+  transition: background .15s, border-color .15s, color .15s;
+}
+.series-start-btn:hover {
+  background: rgba(139, 92, 246, .22);
+  border-color: #a78bfa;
+  color: #c4b5fd;
+}
+
+.series-post-list-wrap {
+  position: relative;
+  &:not(.expanded) .series-post-item:nth-child(n+4) { display: none; }
+}
+
+.series-post-fade {
+  height: 56px;
+  margin-top: -56px;
+  background: linear-gradient(to bottom, transparent, var(--bg-card));
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+  .series-post-list-wrap.expanded & { display: none; }
+}
+
+.series-show-more {
+  display: inline-flex;
+  align-items: center;
+  font-size: .78rem;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--text-3);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: color .15s;
+  &:hover { color: var(--text); }
+}
+
+.series-post-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: none;
+}
+
+.series-post-item {
+  margin: 0;
+  border-bottom: 1px solid var(--border);
+}
+.series-post-item:last-child { border-bottom: none; }
+
+.series-post-link {
+  display: flex;
+  align-items: flex-start;
+  gap: .85rem;
+  padding: .85rem 1.5rem;
+  text-decoration: none;
+  transition: background .15s;
+}
+.series-post-link:hover { background: var(--bg-card-2); }
+
+.series-post-num {
+  flex-shrink: 0;
+  width: 1.6rem;
+  height: 1.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: .7rem;
+  font-weight: 600;
+  color: #8b5cf6;
+  background: rgba(139, 92, 246, .1);
+  border: 1px solid rgba(139, 92, 246, .2);
+  border-radius: 50%;
+  margin-top: .1rem;
+  line-height: 1;
+}
+
+.series-post-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: .2rem;
+}
+
+.series-post-title {
+  font-size: .9rem;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.4;
+}
+.series-post-link:hover .series-post-title { color: var(--accent-h); }
+
+.series-post-desc {
+  font-size: .78rem;
+  color: var(--text-3);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.series-post-date {
+  flex-shrink: 0;
+  font-size: .72rem;
+  color: var(--text-3);
+  padding-top: .15rem;
+  white-space: nowrap;
+}
+
+.series-post-time {
+  flex-shrink: 0;
+  font-size: .72rem;
+  color: var(--text-3);
+  padding-top: .15rem;
+  white-space: nowrap;
+}
+
+.series-empty {
+  color: var(--text-3);
+  font-size: .9rem;
+  padding: 2rem 0;
+}
+
+.page-description {
+  color: var(--text-3);
+  font-size: .95rem;
+  margin-top: .35rem;
+}
+
+/* ============================================================
    RESPONSIVE
    ============================================================ */
 
@@ -1471,6 +1922,9 @@ figcaption {
 }
 
 @media (max-width: 768px) {
+  .series-card-info-actions { margin-left: 0; margin-top: .25rem; }
+  .series-post-link { padding: .75rem 1rem; }
+
   .nav-toggle { display: flex; }
 
   .site-nav {

--- a/series.md
+++ b/series.md
@@ -1,0 +1,125 @@
+---
+layout: default
+title: Series
+permalink: /series/
+---
+<div class="container series-page">
+  <header class="page-header">
+    <h1>Series</h1>
+    <p class="page-description">Multi-part guides that build up from scratch to a complete, working system.</p>
+  </header>
+
+  {%- if site.data.series.size == 0 -%}
+    <p class="series-empty">No series yet.</p>
+  {%- else -%}
+  <div class="series-list">
+    {%- for s in site.data.series -%}
+      {%- assign series_posts = site.series | where: "series", s.name | sort: "series_part" -%}
+      {%- assign first_post = series_posts | first -%}
+
+      {%- assign total_words = 0 -%}
+      {%- for post in series_posts -%}
+        {%- assign pw = post.content | number_of_words -%}
+        {%- assign total_words = total_words | plus: pw -%}
+      {%- endfor -%}
+      {%- assign total_rt = total_words | divided_by: 200 | at_least: 1 -%}
+
+      <div class="series-card" id="{{ s.slug }}">
+
+        {%- if s.image -%}
+        <div class="series-card-image">
+          <img src="{{ s.image | relative_url }}" alt="{{ s.name | escape }}">
+        </div>
+        {%- endif -%}
+
+        <div class="series-card-header">
+          <span class="series-card-label">Series</span>
+          <h2 class="series-card-title">{{ s.name | escape }}</h2>
+          {%- if s.description -%}
+          <p class="series-card-desc">{{ s.description | escape }}</p>
+          {%- endif -%}
+          <div class="series-card-info">
+            <span class="series-card-count">{{ series_posts.size }} parts</span>
+            <span class="series-card-total-time">{{ total_rt }} min total</span>
+            <span class="series-card-dates">{{ s.date }}</span>
+            <span class="series-card-info-actions">
+              {%- if s.github -%}
+              <a href="{{ s.github }}" class="series-repo-btn" target="_blank" rel="noopener" aria-label="Source repository">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                Repo
+              </a>
+              {%- endif -%}
+              <button class="series-share-btn" data-url="{{ site.url }}/series/#{{ s.slug }}" aria-label="Copy link to series">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+                <span class="series-share-label">Share</span>
+              </button>
+            </span>
+          </div>
+        </div>
+
+        <div class="series-post-list-wrap{% if series_posts.size > 3 %} has-more{% endif %}">
+          <ol class="series-post-list">
+            {%- for post in series_posts -%}
+              {%- assign post_words = post.content | number_of_words -%}
+              {%- assign post_rt = post_words | divided_by: 200 | at_least: 1 -%}
+            <li class="series-post-item">
+              <a href="{{ post.url | relative_url }}" class="series-post-link">
+                <span class="series-post-num">{{ post.series_part }}</span>
+                <span class="series-post-body">
+                  <span class="series-post-title">{{ post.title | escape }}</span>
+                  {%- if post.description -%}
+                  <span class="series-post-desc">{{ post.description | escape }}</span>
+                  {%- endif -%}
+                </span>
+                <span class="series-post-time">{{ post_rt }} min</span>
+              </a>
+            </li>
+            {%- endfor -%}
+          </ol>
+          {%- if series_posts.size > 3 -%}
+          <div class="series-post-fade"></div>
+          {%- endif -%}
+        </div>
+
+        <div class="series-card-bottom">
+          {%- if series_posts.size > 3 -%}
+          <button class="series-show-more" data-more="{{ series_posts.size | minus: 3 }}">Show {{ series_posts.size | minus: 3 }} more posts ↓</button>
+          {%- else -%}
+          <span></span>
+          {%- endif -%}
+          {%- if first_post -%}
+          <a href="{{ first_post.url | relative_url }}" class="series-start-btn">Start reading →</a>
+          {%- endif -%}
+        </div>
+
+      </div>
+    {%- endfor -%}
+  </div>
+  {%- endif -%}
+</div>
+
+<script>
+  document.querySelectorAll('.series-share-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var label = btn.querySelector('.series-share-label');
+      navigator.clipboard.writeText(btn.dataset.url).then(function () {
+        label.textContent = 'Copied!';
+        btn.classList.add('series-share-btn--copied');
+        setTimeout(function () {
+          label.textContent = 'Share';
+          btn.classList.remove('series-share-btn--copied');
+        }, 2000);
+      });
+    });
+  });
+
+  document.querySelectorAll('.series-show-more').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var wrap = btn.closest('.series-card').querySelector('.series-post-list-wrap');
+      var isExpanded = wrap.classList.toggle('expanded');
+      btn.textContent = isExpanded
+        ? 'Show less ↑'
+        : 'Show ' + btn.dataset.more + ' more posts ↓';
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary

- Adds Jekyll `series` collection with output enabled and `/posts/:path/` permalinks
- Sticky reading bar that appears when the post title scrolls out of view; includes a series dropdown (numbered list, current post highlighted) driven by `series_part` front-matter
- Series-aware prev/next navigation for collection posts (replaces the previous `site.posts`-only logic)
- `/series` landing page (`series.md`) and `_data/series.yml` registry
- Adds "Series" link to the main nav
- All associated CSS for reading bar, series panel, nav, and tag pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)